### PR TITLE
api feat: adds method to find dependentInvalidTxs

### DIFF
--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -64,6 +64,10 @@ func (b *EthAPIBackend) SetHead(number uint64) {
 	b.eth.blockchain.SetHead(number)
 }
 
+func (b *EthAPIBackend) BlockChain() *core.BlockChain {
+	return b.eth.blockchain
+}
+
 func (b *EthAPIBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Header, error) {
 	// Pending block is only known by the miner
 	if number == rpc.PendingBlockNumber {

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -98,6 +98,10 @@ func (b *testBackend) HeaderByHash(ctx context.Context, hash common.Hash) (*type
 	return b.chain.GetHeaderByHash(hash), nil
 }
 
+func (b *testBackend) BlockChain() *core.BlockChain {
+	return b.chain
+}
+
 func (b *testBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Header, error) {
 	if number == rpc.PendingBlockNumber || number == rpc.LatestBlockNumber {
 		return b.chain.CurrentHeader(), nil

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -387,6 +387,12 @@ web3._extend({
 			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter, null]
 		}),
 		new web3._extend.Method({
+			name: 'findDependentInvalidTxs',
+			call: 'debug_findDependentInvalidTxs',
+			params: 2,
+			inputFormatter: [null, null],
+		}),
+		new web3._extend.Method({
 			name: 'traceBlockByHash',
 			call: 'debug_traceBlockByHash',
 			params: 2,


### PR DESCRIPTION
This PR adds a method called FindDependentInvalidTxs.  It execute blocks while skipping the input txs to finds the number of dependent txs that become invalid. 

Some reasons where txs can become invalid are: 

- Tx Nonce is not equal to the account's nonce + 1
- Not enough funds

